### PR TITLE
Don't assume `listdir` returns a sorted listing

### DIFF
--- a/tests/test_file_processing.py
+++ b/tests/test_file_processing.py
@@ -21,7 +21,7 @@ def test_processes_each_file(tmpdir, processes, stderr, stdin):
     )
     each.clear_queue()
 
-    for i, f in enumerate(output_files.listdir()):
+    for i, f in enumerate(sorted(output_files.listdir())):
         out = f.join("out")
         err = f.join("err")
         status = f.join("status")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -18,7 +18,7 @@ def test_processes_each_file(tmpdir, cat):
         [sys.executable, "-m", "each", str(input_files), cat, "--destination=%s" % (output_files,)]
     )
 
-    for i, f in enumerate(output_files.listdir()):
+    for i, f in enumerate(sorted(output_files.listdir())):
         out = f.join("out")
         err = f.join("err")
         status = f.join("status")


### PR DESCRIPTION
On my laptop (OS X 10.13.6), the `test_processes_each_file` tests fail with errors like these:

```
Traceback (most recent call last):
  File "/Users/jml/src/each/tests/test_main.py", line 31, in test_processes_each_file
    assert out.read().strip() == "hello %d" % (i,)
AssertionError: assert 'hello 9' == 'hello 0'
  - hello 9
  ?       ^
  + hello 0
  ?       ^
```

Sorting the directory listing before enumerating files makes the tests pass again.