### PR TITLE
Short `-j` alias for `--processes`

### DIFF
--- a/src/each/__main__.py
+++ b/src/each/__main__.py
@@ -58,10 +58,10 @@ overwritten.
     ),
 )
 @click.option(
-    "--processes",
+    "--processes", "-j",
     default=max(1, mp.cpu_count() - 1),
     help="""
-The number of child processes to run.""",
+The number of child processes to run in parallel.""",
 )
 @click.option(
     "--stdin/--no-stdin",

--- a/src/each/__main__.py
+++ b/src/each/__main__.py
@@ -58,7 +58,8 @@ overwritten.
     ),
 )
 @click.option(
-    "--processes", "-j",
+    "--processes",
+    "-j",
     default=max(1, mp.cpu_count() - 1),
     help="""
 The number of child processes to run in parallel.""",


### PR DESCRIPTION
Fixes #9

Expands the documentation for the option to include the phrase "in parallel", which is useful for keyword-triggered readers like myself.

Adds a `-j` option, which is a common way of defining parallelism in other tools.