### PR TITLE
Support for line-based processing of a single file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 *.swp
 *.egg-info
 .coverage
+.hypothesis
 .pytest_cache
 dist

--- a/Pipfile
+++ b/Pipfile
@@ -14,6 +14,7 @@ isort = "*"
 flake8 = "*"
 ipython = "*"
 mock = "*"
+hypothesis = "*"
 
 [requires]
 python_version = "3.6"

--- a/README.rst
+++ b/README.rst
@@ -93,14 +93,6 @@ Windows. I'm not against Windows support if someone wants to contribute it, but 
 be writing it myself and it's a fairly unixy sort of tool.
 
 
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-Why isn't this tested with `Hypothesis <https://github.com/HypothesisWorks/hypothesis>`_?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-Look, buddy, you're lucky it's tested at *all*.
-
-(It probably will be at some point)
-
 ~~~~~~~~~~~~~~~~~~
 Should I use this?
 ~~~~~~~~~~~~~~~~~~

--- a/src/each/__init__.py
+++ b/src/each/__init__.py
@@ -1,4 +1,4 @@
-from each.each import SHELL, Each
+from each.each import SHELL, Each, work_items_from_path
 from each.version import __version__, __version_info__
 
-__all__ = ["Each", "__version__", "__version_info__", "SHELL"]
+__all__ = ["Each", "__version__", "__version_info__", "SHELL", "work_items_from_path"]

--- a/src/each/__main__.py
+++ b/src/each/__main__.py
@@ -4,7 +4,7 @@ from datetime import datetime, timedelta
 import click
 from tqdm import tqdm
 
-from each import SHELL, Each
+from each import SHELL, Each, work_items_from_path
 
 
 @click.command(
@@ -93,8 +93,9 @@ def main(command, source, destination, recreate, processes, stdin, shell):
             else:
                 pb.set_postfix(eta=eta.strftime("%Y-%m-%d %H:%M"))
 
+        work_items = work_items_from_path(source)
         each = Each(
-            source=source,
+            work_items=work_items,
             shell=shell,
             destination=destination,
             command=command,

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -76,8 +76,9 @@ class FileWorkItem(WorkItem):
     def as_argument(self):
         return os.path.abspath(self.path)
 
-    def write_in_file(self, _path):
-        """We don't write ``in`` files for file work items."""
+    def write_in_file(self, path):
+        """The ``in`` file is a symlink to the original file."""
+        os.symlink(os.path.abspath(self.path), path)
 
 
 @attr.s()

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -81,12 +81,12 @@ class Each(object):
             pass
 
         for s in os.listdir(self.source):
-            source_file = os.path.join(self.source, s)
-            status_file = os.path.join(self.destination, s, "status")
+            work_item = FileWorkItem(name=s, path=os.path.join(self.source, s))
+            status_file = os.path.join(self.destination, work_item.name, "status")
             if not self.recreate and os.path.exists(status_file):
                 self.progress_callback()
             else:
-                self.work_queue.append(FileWorkItem(name=s, path=source_file))
+                self.work_queue.append(work_item)
         # By iterating in random order, we can paradoxically get much better predictability
         # about the final run time! This allows us to conclude the times we've seen so far
         # are reasonably representative of the times we will see in future.

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -122,7 +122,8 @@ def work_items_from_path(path):
     try:
         return work_items_from_directory(path)
     except NotADirectoryError:
-        return work_items_from_file(path)
+        with open(path, 'r') as stream:
+            return work_items_from_file(stream)
 
 
 def work_items_from_directory(path):
@@ -136,13 +137,15 @@ def work_items_from_directory(path):
     )
 
 
-def work_items_from_file(path):
+def work_items_from_file(stream):
     """Yield a series of work items derived from an iterator of lines.
 
-    We expect each line to be a ``str`` with the newline already stripped.
+    We expect each line to be a ``str`` with the newline already stripped, as
+    happens automatically with open files, or with ``StringIO`` with universal
+    newline decoding.
     """
     items = {}
-    for line in open(path, 'r'):
+    for line in stream:
         name = hashlib.sha256(line.encode('utf-8')).hexdigest()[-8:]
         items[name] = LineWorkItem(name, line)
     return items.values()

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -1,5 +1,6 @@
 import hashlib
 import os
+import re
 import shlex
 import shutil
 import time
@@ -134,6 +135,18 @@ def work_items_from_directory(path):
     return (FileWorkItem(name=s, path=os.path.join(path, s)) for s in os.listdir(path))
 
 
+"""What we consider a 'simple name'.
+
+These are appended to the hashes of lines when generating output,
+as a convenience to the humans who must contend with it.
+"""
+simple_name_re = re.compile("^[A-Za-z0-9_-]+$")
+
+
+"""The longest simple name we allow."""
+MAX_NAME_LENGTH = 100
+
+
 def work_items_from_file(stream):
     """Yield a series of work items derived from an iterator of lines.
 
@@ -144,6 +157,8 @@ def work_items_from_file(stream):
     items = {}
     for line in stream:
         name = hashlib.sha256(line.encode("utf-8")).hexdigest()[-8:]
+        if simple_name_re.match(line.strip()):
+            name += "-" + line.strip()[:MAX_NAME_LENGTH]
         items[name] = LineWorkItem(name, line)
     return items.values()
 

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -104,6 +104,7 @@ class LineWorkItem(WorkItem):
     def as_input_file(self):
         r, w = os.pipe()
         os.write(w, self.line.encode("utf-8"))
+        os.close(w)
         return r
 
     def as_argument(self):

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -145,8 +145,8 @@ as a convenience to the humans who must contend with it.
 simple_name_re = re.compile("^[A-Za-z0-9_-]+$")
 
 
-"""The longest simple name we allow."""
-MAX_NAME_LENGTH = 100
+"""The longest simple name we allow as a suffix to the generated filename."""
+MAX_SIMPLE_NAME_SUFFIX_LENGTH = 100
 
 
 def work_items_from_lines(stream):
@@ -160,7 +160,7 @@ def work_items_from_lines(stream):
     for line in stream:
         name = hashlib.sha256(line.encode("utf-8")).hexdigest()[-8:]
         if simple_name_re.match(line.strip()):
-            name += "-" + line.strip()[:MAX_NAME_LENGTH]
+            name += "-" + line.strip()[:MAX_SIMPLE_NAME_SUFFIX_LENGTH]
         items[name] = LineWorkItem(name, line)
     return items.values()
 

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -105,7 +105,7 @@ class LineWorkItem(WorkItem):
         return r
 
     def as_argument(self):
-        return self.line.rstrip('\n')
+        return self.line.rstrip("\n")
 
     def write_in_file(self, path):
         """The ``in`` file for a line work item is a file with just that line."""
@@ -122,7 +122,7 @@ def work_items_from_path(path):
     try:
         return work_items_from_directory(path)
     except NotADirectoryError:
-        with open(path, 'r') as stream:
+        with open(path, "r") as stream:
             return work_items_from_file(stream)
 
 
@@ -131,10 +131,7 @@ def work_items_from_directory(path):
 
     Each file in the directory is a work item.
     """
-    return (
-        FileWorkItem(name=s, path=os.path.join(path, s))
-        for s in os.listdir(path)
-    )
+    return (FileWorkItem(name=s, path=os.path.join(path, s)) for s in os.listdir(path))
 
 
 def work_items_from_file(stream):
@@ -146,7 +143,7 @@ def work_items_from_file(stream):
     """
     items = {}
     for line in stream:
-        name = hashlib.sha256(line.encode('utf-8')).hexdigest()[-8:]
+        name = hashlib.sha256(line.encode("utf-8")).hexdigest()[-8:]
         items[name] = LineWorkItem(name, line)
     return items.values()
 

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -160,7 +160,7 @@ class Each(object):
         except NotADirectoryError:
             items = (
                 LineWorkItem(name=line.strip(), line=line.strip())
-                for line in open(self.source, "r").readlines()
+                for line in set(open(self.source, "r").readlines())
             )
 
         for work_item in items:

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -31,9 +31,15 @@ class WorkInProgress:
 
 @attr.s()
 class Each(object):
+    """Run a single command on many files in a directory."""
+
+    """A path to a directory containing files to process."""
     source = attr.ib()
+    """A path to a directory where we will create the output files."""
     destination = attr.ib()
+    """The command to run on files in the source directory. This is a single string."""
     command = attr.ib()
+    """The number of processes to run in parallel."""
     processes = attr.ib(default=1)
     recreate = attr.ib(default=False)
     stdin = attr.ib(default=True)

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -82,7 +82,7 @@ class FileWorkItem(WorkItem):
 
 
 @attr.s()
-class LineWorkItem:
+class LineWorkItem(WorkItem):
     """A line to be processed by ``Each``."""
 
     """A name for this work item that can be used as a filename."""

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -51,6 +51,9 @@ class FileWorkItem:
         """This work item as a command-line argument."""
         return os.path.abspath(self.path)
 
+    def write_in_file(self, _path):
+        """We don't write ``in`` files for file work items."""
+
 
 @attr.s()
 class LineWorkItem:
@@ -83,6 +86,12 @@ class LineWorkItem:
     def as_argument(self):
         """This work item as a command-line argument."""
         return self.line
+
+    def write_in_file(self, path):
+        """The ``in`` file for a line work item is a file with just that line."""
+        with open(path, 'w') as in_file:
+            in_file.write(self.line)
+            in_file.write('\n')
 
 
 @attr.s()
@@ -156,12 +165,13 @@ class Each(object):
 
             base_dir = os.path.join(self.destination, work_item.name)
 
+            in_file = os.path.join(base_dir, "in")
             out_file = os.path.join(base_dir, "out")
             err_file = os.path.join(base_dir, "err")
             status_file = os.path.join(base_dir, "status")
 
             if os.path.exists(base_dir):
-                for f in [out_file, err_file, status_file]:
+                for f in [in_file, out_file, err_file, status_file]:
                     if os.path.exists(f):
                         os.unlink(f)
 
@@ -169,6 +179,8 @@ class Each(object):
                 os.makedirs(base_dir)
             except FileExistsError:
                 pass
+
+            work_item.write_in_file(in_file)
 
             pid = None
             pid = os.fork()

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -33,15 +33,15 @@ class WorkInProgress:
 class FileWorkItem:
     """A file to be processed by ``Each``."""
 
+    """A name for this work item that can be used as a filename."""
+    name = attr.ib()
+
+    """The location of the file on disk."""
     path = attr.ib()
 
     def exists(self):
         """Whether or not this work item still exists."""
         return os.path.exists(self.path)
-
-    def name(self):
-        """A name for this work item that can be used as a filename."""
-        return os.path.basename(self.path)
 
     def as_input_file(self):
         """This work item as a file descriptor, that can be passed to STDIN."""
@@ -86,7 +86,7 @@ class Each(object):
             if not self.recreate and os.path.exists(status_file):
                 self.progress_callback()
             else:
-                self.work_queue.append(FileWorkItem(source_file))
+                self.work_queue.append(FileWorkItem(name=s, path=source_file))
         # By iterating in random order, we can paradoxically get much better predictability
         # about the final run time! This allows us to conclude the times we've seen so far
         # are reasonably representative of the times we will see in future.
@@ -104,9 +104,8 @@ class Each(object):
             if not work_item.exists():
                 self.progress_callback()
                 continue
-            name = work_item.name()
 
-            base_dir = os.path.join(self.destination, name)
+            base_dir = os.path.join(self.destination, work_item.name)
 
             out_file = os.path.join(base_dir, "out")
             err_file = os.path.join(base_dir, "err")

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -108,7 +108,7 @@ class LineWorkItem(WorkItem):
         return r
 
     def as_argument(self):
-        return self.line.rstrip("\n")
+        return self.line.rstrip("\r\n")
 
     def write_in_file(self, path):
         """The ``in`` file for a line work item is a file with just that line."""

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -158,10 +158,7 @@ class Each(object):
                 for s in os.listdir(self.source)
             )
         except NotADirectoryError:
-            items = (
-                LineWorkItem(name=line.strip(), line=line.strip())
-                for line in set(open(self.source, "r").readlines())
-            )
+            items = iter_work_items_for_lines(open(self.source, "r").readlines())
 
         for work_item in items:
             status_file = os.path.join(self.destination, work_item.name, "status")
@@ -282,3 +279,17 @@ class Each(object):
             self.fill_work_in_progress()
             self.update_predicted_timing()
             self.collect_completed_work()
+
+
+def iter_work_items_for_lines(lines):
+    """Yield a series of work items derived from an iterator of lines.
+
+    We expect each line to be a ``str`` with the newline already stripped.
+    """
+    # TODO: This incorrectly handles duplicate lines on case insensitive file systems.
+    # TODO: What about lines that contain /
+    # TODO: What about blank lines?
+    return (
+        LineWorkItem(name=line.strip(), line=line.strip())
+        for line in set(lines)
+    )

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -126,7 +126,7 @@ def work_items_from_path(path):
         return work_items_from_directory(path)
     except NotADirectoryError:
         with open(path, "r") as stream:
-            return work_items_from_file(stream)
+            return work_items_from_lines(stream)
 
 
 def work_items_from_directory(path):
@@ -149,7 +149,7 @@ simple_name_re = re.compile("^[A-Za-z0-9_-]+$")
 MAX_NAME_LENGTH = 100
 
 
-def work_items_from_file(stream):
+def work_items_from_lines(stream):
     """Yield a series of work items derived from an iterator of lines.
 
     We expect each line to be a ``str`` with the newline already stripped, as

--- a/src/each/each.py
+++ b/src/each/each.py
@@ -158,7 +158,7 @@ class Each(object):
                 for s in os.listdir(self.source)
             )
         except NotADirectoryError:
-            items = iter_work_items_for_lines(open(self.source, "r").readlines())
+            items = iter_work_items_for_lines(open(self.source, "r"))
 
         for work_item in items:
             status_file = os.path.join(self.destination, work_item.name, "status")

--- a/tests/common.py
+++ b/tests/common.py
@@ -2,10 +2,26 @@
 
 
 def get_contents(path):
-    """Get the contents of 'path' if it exists."""
-    return path.read().strip() if path.check() else None
+    """Get the contents of 'path' if it exists.
+
+    Strips any trailing newlines.
+    """
+    return path.read().rstrip('\n') if path.check() else None
 
 
 def get_directory_contents(path):
     """Get the contents of many files under 'path'."""
     return {child.basename: get_contents(child) for child in path.listdir()}
+
+
+def gather_output(path):
+    """Get all the output, grouped by input contents."""
+    output = {}
+    for f in path.listdir():
+        contents = get_directory_contents(f)
+        input_data = contents["in"]
+        if input_data in output:
+            output[input_data].append(contents)
+        else:
+            output[input_data] = [contents]
+    return output

--- a/tests/common.py
+++ b/tests/common.py
@@ -6,7 +6,7 @@ def get_contents(path):
 
     Strips any trailing newlines.
     """
-    return path.read().rstrip('\n') if path.check() else None
+    return path.read().rstrip("\n") if path.check() else None
 
 
 def get_directory_contents(path):

--- a/tests/common.py
+++ b/tests/common.py
@@ -1,0 +1,11 @@
+"""Test helpers."""
+
+
+def get_contents(path):
+    """Get the contents of 'path' if it exists."""
+    return path.read().strip() if path.check() else None
+
+
+def get_directory_contents(path):
+    """Get the contents of many files under 'path'."""
+    return {child.basename: get_contents(child) for child in path.listdir()}

--- a/tests/test_file_processing.py
+++ b/tests/test_file_processing.py
@@ -1,5 +1,6 @@
 import pytest
 
+from common import get_directory_contents
 from each import Each
 
 
@@ -22,20 +23,11 @@ def test_processes_each_file(tmpdir, processes, stderr, stdin):
     each.clear_queue()
 
     for i, f in enumerate(sorted(output_files.listdir())):
-        out = f.join("out")
-        err = f.join("err")
-        status = f.join("status")
-
-        assert out.check()
-        assert err.check()
-        assert status.check()
-
+        contents = "hello %d" % (i,)
+        expected = {"status": "0", "in": contents, "out": contents, "err": ""}
         if stderr:
-            err, out = out, err
-
-        assert err.read().strip() == ""
-        assert out.read().strip() == "hello %d" % (i,)
-        assert status.read().strip() == "0"
+            expected.update({"out": "", "err": contents})
+        assert get_directory_contents(f) == expected
 
 
 def test_does_not_recreate_by_default(tmpdir):

--- a/tests/test_file_processing.py
+++ b/tests/test_file_processing.py
@@ -2,6 +2,7 @@ import pytest
 
 from common import get_directory_contents
 from each import Each
+from each.each import LineWorkItem, work_items_from_directory
 
 
 @pytest.mark.parametrize("processes", [1, 2, 4])
@@ -15,7 +16,7 @@ def test_processes_each_file(tmpdir, processes, stderr, stdin):
         p.write("hello %d" % (i,))
     each = Each(
         command=("cat >&2 " if stderr else "cat") + (" {}" if not stdin else ""),
-        source=input_files,
+        work_items=work_items_from_directory(input_files),
         destination=output_files,
         processes=processes,
         stdin=stdin,
@@ -31,19 +32,16 @@ def test_processes_each_file(tmpdir, processes, stderr, stdin):
 
 
 def test_does_not_recreate_by_default(tmpdir):
-    input_files = tmpdir.mkdir("input")
     output_files = tmpdir.mkdir("output")
     marker = tmpdir.join("marker")
 
     marker.write("stuff")
 
-    input_files.join("hello").write("")
-
     for _ in range(2):
         each = Each(
             command="cat %s" % (marker,),
             stdin=False,
-            source=input_files,
+            work_items=[LineWorkItem("hello", "")],
             destination=output_files,
             processes=1,
         )
@@ -73,7 +71,7 @@ def test_recreates_if_set(tmpdir, bad_crash):
         each = Each(
             command="cat %s" % (marker,),
             stdin=False,
-            source=input_files,
+            work_items=work_items_from_directory(input_files),
             destination=output_files,
             processes=1,
             recreate=True,
@@ -97,7 +95,7 @@ def test_can_handle_disappearing_files(tmpdir):
     each = Each(
         command="cat",
         stdin=False,
-        source=input_files,
+        work_items=work_items_from_directory(input_files),
         destination=output_files,
         processes=1,
         recreate=True,
@@ -113,14 +111,11 @@ def test_can_handle_disappearing_files(tmpdir):
 
 
 def test_timeout_in_file_processing(tmpdir):
-
-    input_files = tmpdir.mkdir("input")
     output_files = tmpdir.mkdir("output")
-    input_files.join("hello").write("world")
 
     each = Each(
         command="sleep 0.5 && cat",
-        source=input_files,
+        work_items=[LineWorkItem("hello", "world")],
         destination=output_files,
         processes=1,
         recreate=True,
@@ -130,7 +125,7 @@ def test_timeout_in_file_processing(tmpdir):
     each.clear_queue()
 
     assert len(output_files.listdir()) == 1
-    assert output_files.join("hello").join("out").read() == "world"
+    assert output_files.join("hello").join("out").read() == "world\n"
 
 
 def test_immediately_triggers_progress_on_initially_completed_work(tmpdir):
@@ -150,7 +145,7 @@ def test_immediately_triggers_progress_on_initially_completed_work(tmpdir):
 
         each = Each(
             command="true",
-            source=input_files,
+            work_items=work_items_from_directory(input_files),
             destination=output_files,
             processes=1,
             recreate=False,

--- a/tests/test_file_processing.py
+++ b/tests/test_file_processing.py
@@ -125,7 +125,7 @@ def test_timeout_in_file_processing(tmpdir):
     each.clear_queue()
 
     assert len(output_files.listdir()) == 1
-    assert output_files.join("hello").join("out").read() == "world\n"
+    assert output_files.join("hello").join("out").read() == "world"
 
 
 def test_immediately_triggers_progress_on_initially_completed_work(tmpdir):

--- a/tests/test_forking.py
+++ b/tests/test_forking.py
@@ -24,6 +24,7 @@ APPROVED_NAMES = {
     "O_RDONLY",
     "open",
     "getpid",
+    "symlink",
 }
 
 

--- a/tests/test_forking.py
+++ b/tests/test_forking.py
@@ -97,7 +97,10 @@ def test_will_show_exception_if_exec_fails(child_test, capsys, tmpdir, stdin, li
             input_path.join("hello").write("")
 
         each = Each(
-            command="cat", source=input_path, destination=tmpdir.mkdir("output"), stdin=stdin
+            command="cat",
+            work_items=each_module.work_items_from_path(input_path),
+            destination=tmpdir.mkdir("output"),
+            stdin=stdin,
         )
 
         each.clear_queue()

--- a/tests/test_forking.py
+++ b/tests/test_forking.py
@@ -49,10 +49,21 @@ class FakeOS(object):
     def dup2(self, fd1, fd2, inheritable=True):
         self.process_table[fd2] = fd2
 
-    def dup(self, fd1):
+    def _get_next_fd(self):
         res = self.next_fd
         self.next_fd += 1
         return res
+
+    def dup(self, fd1):
+        return self._get_next_fd()
+
+    def pipe(self):
+        r = self._get_next_fd()
+        w = self._get_next_fd()
+        return (r, w)
+
+    def write(self, fd, data):
+        pass
 
     def close(self, fd):
         self.closed.add(fd)
@@ -72,15 +83,20 @@ def child_test(monkeypatch):
 
 
 @pytest.mark.parametrize("stdin", [False, True])
-def test_will_show_exception_if_exec_fails(child_test, capsys, tmpdir, stdin):
+@pytest.mark.parametrize("line_mode", [False, True])
+def test_will_show_exception_if_exec_fails(child_test, capsys, tmpdir, stdin, line_mode):
     child_test.exec_error = PermissionError
 
     with pytest.raises(SystemExit):
-        input_files = tmpdir.mkdir("input")
-        input_files.join("hello").write("")
+        if line_mode:
+            input_path = tmpdir.join("input")
+            input_path.write("hello\n")
+        else:
+            input_path = tmpdir.mkdir("input")
+            input_path.join("hello").write("")
 
         each = Each(
-            command="cat", source=input_files, destination=tmpdir.mkdir("output"), stdin=stdin
+            command="cat", source=input_path, destination=tmpdir.mkdir("output"), stdin=stdin
         )
 
         each.clear_queue()

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -1,6 +1,51 @@
 import os
 
+import pytest
+
+from each import Each
 from each.each import LineWorkItem
+from test_main import get_directory_contents
+
+
+@pytest.mark.parametrize("processes", [1, 2, 4])
+@pytest.mark.parametrize("stderr", [False, True])
+@pytest.mark.parametrize("stdin", [False, True])
+def test_processes_each_line(tmpdir, processes, stderr, stdin):
+    input_path = tmpdir.join("input")
+    output_path = tmpdir.mkdir("output")
+    with input_path.open("w") as input_file:
+        for i in range(10):
+            input_file.write("hello %d\n" % (i,))
+
+    if stdin:
+        if stderr:
+            command = "cat >&2"
+        else:
+            command = "cat"
+    else:
+        if stderr:
+            command = "echo {} | cat >&2"
+        else:
+            command = "echo {}"
+
+    each = Each(
+        command=command,
+        source=input_path,
+        destination=output_path,
+        processes=processes,
+        stdin=stdin,
+    )
+    each.clear_queue()
+
+    output_files = sorted(output_path.listdir())
+    assert output_files == [output_path.join("hello %d" % (i,)) for i in range(10)]
+
+    for i, f in enumerate(output_files):
+        line = "hello %d" % (i,)
+        expected = {"status": "0", "in": line, "out": line, "err": ""}
+        if stderr:
+            expected.update({"out": "", "err": line})
+        assert get_directory_contents(f) == expected
 
 
 def test_creates_pipe():

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -48,6 +48,28 @@ def test_processes_each_line(tmpdir, processes, stderr, stdin):
         assert get_directory_contents(f) == expected
 
 
+def test_duplicate_lines(tmpdir):
+    """We silently ignore duplicate lines."""
+    input_path = tmpdir.join("input")
+    output_path = tmpdir.mkdir("output")
+    line = "hello"
+    with input_path.open("w") as input_file:
+        input_file.write("%s\n" % (line,))
+        input_file.write("%s\n" % (line,))
+
+    each = Each(
+        command="echo {}",
+        source=input_path,
+        destination=output_path,
+        stdin=False,
+    )
+    each.clear_queue()
+
+    [output_file] = output_path.listdir()
+    expected = {"status": "0", "in": line, "out": line, "err": ""}
+    assert get_directory_contents(output_file) == expected
+
+
 def test_creates_pipe():
     """as_input_file returns a file descriptor from which we can read the original line."""
     line = "foo"

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -1,9 +1,8 @@
 import io
 import os
 
-from hypothesis import given
-from hypothesis import strategies as st
 import pytest
+from hypothesis import given, strategies as st
 
 from common import gather_output, get_directory_contents
 from each import Each, work_items_from_path
@@ -20,7 +19,7 @@ def test_processes_each_line(tmpdir, processes, stderr, stdin):
     with input_path.open("w") as input_file:
         for line in lines:
             input_file.write(line)
-            input_file.write('\n')
+            input_file.write("\n")
 
     if stdin:
         if stderr:
@@ -56,10 +55,7 @@ def test_duplicate_lines(tmpdir):
 
     each = Each(
         command="echo {}",
-        work_items=[
-            LineWorkItem(line, line),
-            LineWorkItem(line, line),
-        ],
+        work_items=[LineWorkItem(line, line), LineWorkItem(line, line)],
         destination=output_path,
         stdin=False,
     )
@@ -77,14 +73,7 @@ def test_awkward_lines(tmpdir):
 
     # We hit the deadline limit pretty query if we let Hypothesis generate
     # examples. Instead, let's provide a few of the ones that tripped us up.
-    input_data = '\n'.join([
-        '',
-        ' ',
-        '*',
-        '\r',
-        'some/path',
-        'no-trailing-newline'
-    ])
+    input_data = "\n".join(["", " ", "*", "\r", "some/path", "no-trailing-newline"])
     # splitlines() here as this turns the line w/ '\r' into an empty line, and
     # is what we'd do if we had Hypothesis generate data in the same way as
     # test_unique_named_work_items.
@@ -110,10 +99,11 @@ def test_unique_named_work_items(data):
 
     This allows ``Each`` to safely create directories based on the names.
     """
-    input_stream = io.StringIO('\n'.join(data))
+    input_stream = io.StringIO("\n".join(data))
     item_names = [item.name for item in work_items_from_file(input_stream)]
-    assert sorted(list({name.lower() for name in item_names})) \
-        == sorted(name.lower() for name in item_names)
+    assert sorted(list({name.lower() for name in item_names})) == sorted(
+        name.lower() for name in item_names
+    )
 
 
 @given(data=st.text())
@@ -122,5 +112,5 @@ def test_creates_pipe(data):
     line = data.split("\n")[0] if data else ""
     item = LineWorkItem(name="foo", line=line)
     fd = item.as_input_file()
-    output_line = os.read(fd, len(line.encode('utf-8'))).decode('utf-8')
-    assert output_line.strip('\n') == line
+    output_line = os.read(fd, len(line.encode("utf-8"))).decode("utf-8")
+    assert output_line.strip("\n") == line

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -8,7 +8,7 @@ from hypothesis import given, strategies as st
 
 from common import gather_output, get_directory_contents
 from each import Each, work_items_from_path
-from each.each import MAX_NAME_LENGTH, LineWorkItem, work_items_from_lines
+from each.each import MAX_SIMPLE_NAME_SUFFIX_LENGTH, LineWorkItem, work_items_from_lines
 
 
 @pytest.mark.parametrize("processes", [1, 2, 4])
@@ -110,7 +110,9 @@ def test_unique_named_work_items(data):
 
 @given(
     name=st.text(
-        alphabet=string.ascii_letters + string.digits + "-_", min_size=1, max_size=MAX_NAME_LENGTH
+        alphabet=string.ascii_letters + string.digits + "-_",
+        min_size=1,
+        max_size=MAX_SIMPLE_NAME_SUFFIX_LENGTH,
     )
 )
 def test_friendly_names(name):
@@ -122,8 +124,8 @@ def test_friendly_names(name):
 @given(
     name=st.text(
         alphabet=string.ascii_letters + string.digits + "-_",
-        min_size=MAX_NAME_LENGTH,
-        max_size=MAX_NAME_LENGTH * 2,
+        min_size=MAX_SIMPLE_NAME_SUFFIX_LENGTH,
+        max_size=MAX_SIMPLE_NAME_SUFFIX_LENGTH * 2,
     )
 )
 def test_long_names(name):
@@ -134,7 +136,7 @@ def test_long_names(name):
     """
     names = [item.name for item in work_items_from_lines(io.StringIO(name))]
     hash_prefix = hashlib.sha256(name.encode("utf-8")).hexdigest()[-8:]
-    assert names == ["%s-%s" % (hash_prefix, name[:MAX_NAME_LENGTH])]
+    assert names == ["%s-%s" % (hash_prefix, name[:MAX_SIMPLE_NAME_SUFFIX_LENGTH])]
 
 
 @given(data=st.text())

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -6,7 +6,7 @@ import pytest
 
 from common import get_directory_contents
 from each import Each
-from each.each import LineWorkItem
+from each.each import LineWorkItem, work_items_from_file
 
 
 @pytest.mark.parametrize("processes", [1, 2, 4])
@@ -32,7 +32,7 @@ def test_processes_each_line(tmpdir, processes, stderr, stdin):
 
     each = Each(
         command=command,
-        source=input_path,
+        work_items=work_items_from_file(input_path),
         destination=output_path,
         processes=processes,
         stdin=stdin,
@@ -52,16 +52,15 @@ def test_processes_each_line(tmpdir, processes, stderr, stdin):
 
 def test_duplicate_lines(tmpdir):
     """We silently ignore duplicate lines."""
-    input_path = tmpdir.join("input")
     output_path = tmpdir.mkdir("output")
     line = "hello"
-    with input_path.open("w") as input_file:
-        input_file.write("%s\n" % (line,))
-        input_file.write("%s\n" % (line,))
 
     each = Each(
         command="echo {}",
-        source=input_path,
+        work_items=[
+            LineWorkItem(line, line),
+            LineWorkItem(line, line),
+        ],
         destination=output_path,
         stdin=False,
     )

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -1,0 +1,12 @@
+import os
+
+from each.each import LineWorkItem
+
+
+def test_creates_pipe():
+    """as_input_file returns a file descriptor from which we can read the original line."""
+    line = "foo"
+    item = LineWorkItem(name="foo", line=line)
+    fd = item.as_input_file()
+    output_line = os.read(fd, len(line) + 1).decode("utf-8")
+    assert output_line == line + "\n"

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -8,7 +8,7 @@ from hypothesis import given, strategies as st
 
 from common import gather_output, get_directory_contents
 from each import Each, work_items_from_path
-from each.each import MAX_NAME_LENGTH, LineWorkItem, work_items_from_file
+from each.each import MAX_NAME_LENGTH, LineWorkItem, work_items_from_lines
 
 
 @pytest.mark.parametrize("processes", [1, 2, 4])
@@ -85,7 +85,7 @@ def test_awkward_lines(tmpdir):
 
     each = Each(
         command="cat",
-        work_items=work_items_from_file(input_stream),
+        work_items=work_items_from_lines(input_stream),
         destination=output_path,
         stdin=True,
     )
@@ -102,7 +102,7 @@ def test_unique_named_work_items(data):
     This allows ``Each`` to safely create directories based on the names.
     """
     input_stream = io.StringIO("\n".join(data))
-    item_names = [item.name for item in work_items_from_file(input_stream)]
+    item_names = [item.name for item in work_items_from_lines(input_stream)]
     assert sorted(list({name.lower() for name in item_names})) == sorted(
         name.lower() for name in item_names
     )
@@ -115,7 +115,7 @@ def test_unique_named_work_items(data):
 )
 def test_friendly_names(name):
     """If a line has nothing weird in it, we give it a friendly name."""
-    names = [item.name for item in work_items_from_file(io.StringIO(name))]
+    names = [item.name for item in work_items_from_lines(io.StringIO(name))]
     assert names == ["%s-%s" % (hashlib.sha256(name.encode("utf-8")).hexdigest()[-8:], name)]
 
 
@@ -132,7 +132,7 @@ def test_long_names(name):
     If a line has nothing weird in it, but is really long, we give it a
     friendly, truncated name.
     """
-    names = [item.name for item in work_items_from_file(io.StringIO(name))]
+    names = [item.name for item in work_items_from_lines(io.StringIO(name))]
     hash_prefix = hashlib.sha256(name.encode("utf-8")).hexdigest()[-8:]
     assert names == ["%s-%s" % (hash_prefix, name[:MAX_NAME_LENGTH])]
 

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -2,9 +2,9 @@ import os
 
 import pytest
 
+from common import get_directory_contents
 from each import Each
 from each.each import LineWorkItem
-from test_main import get_directory_contents
 
 
 @pytest.mark.parametrize("processes", [1, 2, 4])

--- a/tests/test_line_processing.py
+++ b/tests/test_line_processing.py
@@ -1,5 +1,7 @@
 import os
 
+from hypothesis import given
+from hypothesis import strategies as st
 import pytest
 
 from common import get_directory_contents
@@ -70,10 +72,11 @@ def test_duplicate_lines(tmpdir):
     assert get_directory_contents(output_file) == expected
 
 
-def test_creates_pipe():
+@given(data=st.text())
+def test_creates_pipe(data):
     """as_input_file returns a file descriptor from which we can read the original line."""
-    line = "foo"
+    line = data.split("\n")[0] if data else ""
     item = LineWorkItem(name="foo", line=line)
     fd = item.as_input_file()
-    output_line = os.read(fd, len(line) + 1).decode("utf-8")
-    assert output_line == line + "\n"
+    output_line = os.read(fd, len(line.encode('utf-8'))).decode('utf-8')
+    assert output_line.strip('\n') == line

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -5,6 +5,8 @@ from shutil import which
 
 import pytest
 
+from common import get_directory_contents
+
 
 @pytest.mark.parametrize("cat", ["cat", "cat {}"])
 def test_processes_each_file(tmpdir, cat):
@@ -22,7 +24,13 @@ def test_processes_each_file(tmpdir, cat):
     assert output_files == [output_path.join("%d.txt" % (i,)) for i in range(10)]
 
     for i, f in enumerate(output_files):
-        assert get_directory_contents(f) == {"err": "", "status": "0", "out": "hello %d" % (i,)}
+        contents = "hello %d" % (i,)
+        assert get_directory_contents(f) == {
+            "err": "",
+            "status": "0",
+            "out": contents,
+            "in": contents,
+        }
 
 
 @pytest.mark.parametrize("echo", ["cat", "echo {}"])
@@ -49,16 +57,6 @@ def test_processes_each_line(tmpdir, echo):
     for i, f in enumerate(output_files):
         line = "hello %d" % (i,)
         assert get_directory_contents(f) == {"out": line, "in": line, "err": "", "status": "0"}
-
-
-def get_contents(path):
-    """Get the contents of 'path' if it exists."""
-    return path.read().strip() if path.check() else None
-
-
-def get_directory_contents(path):
-    """Get the contents of many files under 'path'."""
-    return {child.basename: get_contents(child) for child in path.listdir()}
 
 
 @pytest.mark.parametrize("shell", [which("sh"), which("bash")])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -22,17 +22,7 @@ def test_processes_each_file(tmpdir, cat):
     assert output_files == [output_path.join("%d.txt" % (i,)) for i in range(10)]
 
     for i, f in enumerate(output_files):
-        out = f.join("out")
-        err = f.join("err")
-        status = f.join("status")
-
-        assert out.check()
-        assert err.check()
-        assert status.check()
-
-        assert err.read().strip() == ""
-        assert out.read().strip() == "hello %d" % (i,)
-        assert status.read().strip() == "0"
+        assert get_directory_contents(f) == {"err": "", "status": "0", "out": "hello %d" % (i,)}
 
 
 @pytest.mark.parametrize("echo", ["cat", "echo {}"])
@@ -57,18 +47,18 @@ def test_processes_each_line(tmpdir, echo):
     assert output_files == [output_path.join("hello %d" % (i,)) for i in range(10)]
 
     for i, f in enumerate(output_files):
-        in_ = f.join("in")
-        out = f.join("out")
-        err = f.join("err")
-        status = f.join("status")
-
         line = "hello %d" % (i,)
-        assert list(map(get_contents, [status, in_, out, err])) == ["0", line, line, ""]
+        assert get_directory_contents(f) == {"out": line, "in": line, "err": "", "status": "0"}
 
 
 def get_contents(path):
     """Get the contents of 'path' if it exists."""
     return path.read().strip() if path.check() else None
+
+
+def get_directory_contents(path):
+    """Get the contents of many files under 'path'."""
+    return {child.basename: get_contents(child) for child in path.listdir()}
 
 
 @pytest.mark.parametrize("shell", [which("sh"), which("bash")])

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -47,7 +47,7 @@ def test_processes_each_line(tmpdir, echo):
     with input_path.open("w") as input_file:
         for line in lines:
             input_file.write(line)
-            input_file.write('\n')
+            input_file.write("\n")
 
     subprocess.check_call(
         [sys.executable, "-m", "each", str(input_path), echo, "--destination=%s" % (output_path,)]

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -35,6 +35,40 @@ def test_processes_each_file(tmpdir, cat):
         assert status.read().strip() == "0"
 
 
+@pytest.mark.parametrize("echo", ["cat", "echo {}"])
+def test_processes_each_line(tmpdir, echo):
+    """When given a file (not a directory) as input, ``each`` will run the given
+    command on each *line* of the file, creating an output directory for that
+    looks a lot like the output directory you get with a directory input,
+    except that each directory also has an ``in`` file, which contains the
+    contents of the input line.
+    """
+    input_path = tmpdir.join("input")
+    output_path = tmpdir.mkdir("output")
+    with input_path.open("w") as input_file:
+        for i in range(10):
+            input_file.write("hello %d\n" % (i,))
+
+    subprocess.check_call(
+        [sys.executable, "-m", "each", str(input_path), echo, "--destination=%s" % (output_path,)]
+    )
+
+    output_files = sorted(output_path.listdir())
+    assert output_files == [output_path.join("hello %d" % (i,)) for i in range(10)]
+
+    for i, f in enumerate(output_files):
+        out = f.join("out")
+        err = f.join("err")
+        status = f.join("status")
+
+        assert list(map(get_contents, [status, out, err])) == ["0", "hello %d" % (i,), ""]
+
+
+def get_contents(path):
+    """Get the contents of 'path' if it exists."""
+    return path.read().strip() if path.check() else None
+
+
 @pytest.mark.parametrize("shell", [which("sh"), which("bash")])
 def test_respects_shell_argument(tmpdir, shell):
     input_files = tmpdir.mkdir("input")

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -57,11 +57,13 @@ def test_processes_each_line(tmpdir, echo):
     assert output_files == [output_path.join("hello %d" % (i,)) for i in range(10)]
 
     for i, f in enumerate(output_files):
+        in_ = f.join("in")
         out = f.join("out")
         err = f.join("err")
         status = f.join("status")
 
-        assert list(map(get_contents, [status, out, err])) == ["0", "hello %d" % (i,), ""]
+        line = "hello %d" % (i,)
+        assert list(map(get_contents, [status, in_, out, err])) == ["0", line, line, ""]
 
 
 def get_contents(path):

--- a/tests/test_main.py
+++ b/tests/test_main.py
@@ -8,17 +8,20 @@ import pytest
 
 @pytest.mark.parametrize("cat", ["cat", "cat {}"])
 def test_processes_each_file(tmpdir, cat):
-    input_files = tmpdir.mkdir("input")
-    output_files = tmpdir.mkdir("output")
+    input_path = tmpdir.mkdir("input")
+    output_path = tmpdir.mkdir("output")
     for i in range(10):
-        p = input_files.join("%d.txt" % (i,))
+        p = input_path.join("%d.txt" % (i,))
         p.write("hello %d" % (i,))
 
     subprocess.check_call(
-        [sys.executable, "-m", "each", str(input_files), cat, "--destination=%s" % (output_files,)]
+        [sys.executable, "-m", "each", str(input_path), cat, "--destination=%s" % (output_path,)]
     )
 
-    for i, f in enumerate(sorted(output_files.listdir())):
+    output_files = sorted(output_path.listdir())
+    assert output_files == [output_path.join("%d.txt" % (i,)) for i in range(10)]
+
+    for i, f in enumerate(output_files):
         out = f.join("out")
         err = f.join("err")
         status = f.join("status")

--- a/tests/test_predicted_timing.py
+++ b/tests/test_predicted_timing.py
@@ -5,7 +5,7 @@ from each.prediction import predict_timing
 
 @pytest.mark.parametrize("parallelism", [1, 4, 10])
 @pytest.mark.parametrize("remaining", [1, 10, 100, 1000])
-@pytest.mark.parametrize("seed", [0, 384139841])
+@pytest.mark.parametrize("seed", [0, 384_139_841])
 @pytest.mark.parametrize("base", [1, 10, 60, 120])
 def test_predictions_based_on_constant_data_are_fairly_consistent(
     parallelism, remaining, seed, base


### PR DESCRIPTION
Fixes #10 

Adds support for line-based processing of files. As discussed, the user interface is such that if a user provides a file, rather than a directory, `each` will do the right thing. 

Output directories are named with an 8-byte suffix of the SHA256 hash of the line (including line ending). If the line had nothing but alphanumeric characters and `-` or `_`, we append that as a suffix for ease of reference.

In addition, all output directories now contain an `in` file. If the source of work items was a file, `in` contains the contents of that file. If a directory, it is a symlink to the original file.

Code-wise, I abstracted out the source of work items, so `Each` itself now takes a list of work items, rather than a `source` path. I also made an interface (an `ABC`) for what work items are. I'm not especially pleased with this interface, but it does the job.

On the tests, I found I wanted some more helpers than were present. This was especially the case after I moved to using hashes in the file names and found I didn't want to explicitly enumerate them.

Not all of the commits would pass a full build. Happy to rebase if desired. 

This is a pretty big PR. If you want me to split it up into a couple of smaller PRs (e.g. one for test helpers, one for work item abstraction, one for new feature), I would be OK to do that.